### PR TITLE
Fix "TypeError: the JSON object must be str, not 'bytes'" for ptc

### DIFF
--- a/pogo/api.py
+++ b/pogo/api.py
@@ -64,7 +64,7 @@ def createPTCSession(username, pw, startLocation):
     session = createRequestsSession()
     logging.info('Creating PTC session for {}'.format(username))
     r = session.get(LOGIN_URL)
-    jdata = json.loads(r.content)
+    jdata = json.loads(r.content.decode())
     data = {
         'lt': jdata['lt'],
         'execution': jdata['execution'],


### PR DESCRIPTION
Because of:

```
Traceback (most recent call last):
  File "demo.py", line 38, in <module>
    session = api.createPTCSession(args.username, args.password, args.location)
  File "/Volumes/development/workspaces/pokemongo-api/pogo/api.py", line 67, in createPTCSession
    jdata = json.loads(r.content)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'
```

if you try to login with a "ptc" account on python 3.4.