### PR TITLE
Change Trainer.setEggs() to put best eggs in all available incubators.

### DIFF
--- a/pogo/trainer.py
+++ b/pogo/trainer.py
@@ -293,15 +293,27 @@ class Trainer(object):
 
     # Set an egg to an incubator
     def setEggs(self):
+        logging.info("Placing eggs in incubators.")
         inventory = self.session.inventory
 
-        # If no eggs, nothing we can do
-        if len(inventory.eggs) == 0:
-            return None
+        # get empty incubators
+        incubators = filter(lambda x: x.pokemon_id == 0, inventory.incubators)
+        logging.info(incubators)
 
-        egg = inventory.eggs[0]
-        incubator = inventory.incubators[0]
-        return self.session.setEgg(incubator, egg)
+        # get available eggs sorted by distance (i.e. favor 10 km over 5 km)
+        eggs = sorted(
+            filter(lambda x: not x.egg_incubator_id, inventory.eggs),
+            key=lambda x: x.egg_km_walked_target - x.egg_km_walked_start,
+            reverse=True)
+        logging.info(eggs)
+
+        # assign the best eggs to empty incubators
+        for i in xrange(min(len(incubators), len(eggs))):
+            incubator = incubators[i]
+            egg = eggs[i]
+            logging.info("Adding egg '%s' to '%s'." % (egg.id, incubator.id))
+            self.session.setEgg(incubator, egg)
+
 
     # Understand this function before you run it.
     # Otherwise you may flush pokemon you wanted.


### PR DESCRIPTION
The current code tries to put the first egg in the list in the first incubator in the list without regard to (a) the egg already being in an incubator or (b) the incubator already containing an egg. Additionally, the current code will only place a single egg in a single incubator in the best case. This change utilizes all empty incubators and prioritizes eggs that are not already in an incubator based on distance (i.e. 10km > 5km >2km).
